### PR TITLE
Complete subscription_transport tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ $ pip install graphql-subscriptions
 
 #### Methods
 - `publish(trigger_name, payload)`: Trigger name is the subscription or pubsub channel; payload is the mutation object or message that will end up being passed to the subscription root_value; method called inside of mutation resolve function
-- `subscribe(query, operation_name, callback, variables, context, format_error, format_response)`: Called by ApolloSubscriptionServer upon receiving a new subscription from a websocket.  Arguments are parsed by ApolloSubscriptionServer from the graphql subscription query
-- `unsubscribe(sub_id)`: Sub_id is the subscription ID that is being tracked by the subscription manager instance -- returned from the `subscribe()` method and called by the ApolloSubscriptionServer
+- `subscribe(query, operation_name, callback, variables, context, format_error, format_response)`: Called by SubscriptionServer upon receiving a new subscription from a websocket.  Arguments are parsed by SubscriptionServer from the graphql subscription query
+- `unsubscribe(sub_id)`: Sub_id is the subscription ID that is being tracked by the subscription manager instance -- returned from the `subscribe()` method and called by the SubscriptionServer
 
-### ApolloSubscriptionServer(subscription_manager, websocket, keep_alive=None, on_subscribe=None, on_unsubscribe=None, on_connect=None, on_disconnect=None)
+### SubscriptionServer(subscription_manager, websocket, keep_alive=None, on_subscribe=None, on_unsubscribe=None, on_connect=None, on_disconnect=None)
 #### Arguments
 - `subscription_manager`: A subscripton manager instance (required).
 - `websocket`: The websocket object passed in from your route handler (required).
@@ -78,7 +78,7 @@ from flask_sockets import Sockets
 from graphql_subscriptions import (
     SubscriptionManager,
     RedisPubsub,
-    ApolloSubscriptionServer
+    SubscriptionServer
 )
 
 app = Flask(__name__)
@@ -106,7 +106,7 @@ subscription_mgr = SubscriptionManager(schema, pubsub)
 # subscription app / server -- passing in subscription manager and websocket
 @sockets.route('/socket')
 def socket_channel(websocket):
-    subscription_server = ApolloSubscriptionServer(subscription_mgr, websocket)
+    subscription_server = SubscriptionServer(subscription_mgr, websocket)
     subscription_server.handle()
     return []
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 #### (Work in Progress!)
 A port of apollographql subscriptions for python, using gevent websockets and redis
 
-This is a implementation of apollographql  [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws) and [graphql-subscriptions](https://github.com/apollographql/graphql-subscriptions) in Python.  It currently implements a pubsub using [redis-py](https://github.com/andymccurdy/redis-py) and uses [gevent-websockets](https://bitbucket.org/noppo/gevent-websocket) for concurrency.  It also makes heavy use of [syrusakbary/promise](https://github.com/syrusakbary/promise) python implementation to mirror the logic in the apollo-graphql libraries.
+This is an implementation of graphql subscriptions in Python.  It uses the apollographql  [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws) and [graphql-subscriptions](https://github.com/apollographql/graphql-subscriptions) packages as its basis.  It currently implements a pubsub using [redis-py](https://github.com/andymccurdy/redis-py) and uses [gevent-websockets](https://bitbucket.org/noppo/gevent-websocket) for concurrency.  It also makes heavy use of [syrusakbary/promise](https://github.com/syrusakbary/promise) python implementation to mirror the logic in the apollo-graphql libraries.
 
-Meant to be used in conjunction with [graphql-python](https://github.com/graphql-python) / [graphene](http://graphene-python.org/) server and [apollo-client](http://dev.apollodata.com/) for graphql.  The api is below, but if you want more information, consult the apollo graphql libraries referenced above.
+Meant to be used in conjunction with [graphql-python](https://github.com/graphql-python) / [graphene](http://graphene-python.org/) server and [apollo-client](http://dev.apollodata.com/) for graphql.  The api is below, but if you want more information, consult the apollo graphql libraries referenced above, and specifcally as it relates to using their graphql subscriptions client.
 
-Initial implementation.  Currently only works with Python 2.
+Initial implementation.  Good test coverage.  Currently only works with Python 2.
 
 ## Installation
 ```

--- a/graphql_subscriptions/__init__.py
+++ b/graphql_subscriptions/__init__.py
@@ -1,4 +1,5 @@
 from subscription_manager import RedisPubsub, SubscriptionManager
-from subscription_transport_ws import ApolloSubscriptionServer
+from subscription_transport_ws import SubscriptionServer
 
-__all__ = ['RedisPubsub', 'SubscriptionManager', 'ApolloSubscriptionServer']
+__all__ = ['RedisPubsub', 'SubscriptionManager', 'SubscriptionServer']
+

--- a/graphql_subscriptions/subscription_transport_ws.py
+++ b/graphql_subscriptions/subscription_transport_ws.py
@@ -77,13 +77,11 @@ class ApolloSubscriptionServer(WebSocketApplication):
         if msg is None:
             return
 
-        class nonlocal:
-            on_init_resolve = None
-            on_init_reject = None
+        nonlocal = {'on_init_resolve': None, 'on_init_reject': None}
 
         def init_promise_handler(resolve, reject):
-            nonlocal.on_init_resolve = resolve
-            nonlocal.on_init_reject = reject
+            nonlocal['on_init_resolve'] = resolve
+            nonlocal['on_init_reject'] = reject
 
         self.connection_context['init_promise'] = Promise(init_promise_handler)
 
@@ -107,7 +105,7 @@ class ApolloSubscriptionServer(WebSocketApplication):
                         self.on_connect(
                             parsed_message.get('payload'), self.ws))
 
-                nonlocal.on_init_resolve(on_connect_promise)
+                nonlocal['on_init_resolve'](on_connect_promise)
 
                 def init_success_promise_handler(result):
                     if not result:
@@ -218,7 +216,7 @@ class ApolloSubscriptionServer(WebSocketApplication):
                 # not sure if this behavior is correct or
                 # not per promises A spec...need to
                 # investigate
-                nonlocal.on_init_resolve(Promise.resolve(True))
+                nonlocal['on_init_resolve'](Promise.resolve(True))
 
                 self.connection_context['init_promise'].then(
                     subscription_start_promise_handler)
@@ -231,7 +229,7 @@ class ApolloSubscriptionServer(WebSocketApplication):
                         del self.connection_subscriptions[sub_id]
 
                 # same rationale as above
-                nonlocal.on_init_resolve(Promise.resolve(True))
+                nonlocal['on_init_resolve'](Promise.resolve(True))
 
                 self.connection_context['init_promise'].then(
                     subscription_end_promise_handler)

--- a/graphql_subscriptions/subscription_transport_ws.py
+++ b/graphql_subscriptions/subscription_transport_ws.py
@@ -15,7 +15,7 @@ INIT_FAIL = 'init_fail'
 GRAPHQL_SUBSCRIPTIONS = 'graphql-subscriptions'
 
 
-class ApolloSubscriptionServer(WebSocketApplication):
+class SubscriptionServer(WebSocketApplication):
     def __init__(self,
                  subscription_manager,
                  websocket,
@@ -37,7 +37,7 @@ class ApolloSubscriptionServer(WebSocketApplication):
         self.connection_subscriptions = {}
         self.connection_context = {}
 
-        super(ApolloSubscriptionServer, self).__init__(websocket)
+        super(SubscriptionServer, self).__init__(websocket)
 
     def timer(self, callback, period):
         while True:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except (IOError, ImportError):
 
 setup(
     name='graphql-subscriptions',
-    version='0.1.7',
+    version='0.1.8',
     author='Heath Ballard',
     author_email='heath.ballard@gmail.com',
     description=('A port of apollo-graphql subscriptions for python, using\
@@ -26,6 +26,11 @@ setup(
         'Programming Language :: Python :: 2.7',
         'License :: OSI Approved :: MIT License'
     ],
-    install_requires=['gevent-websocket', 'redis', 'promise', 'graphql-core'],
-    tests_require=['pytest', 'pytest-mock', 'fakeredis', 'graphene'],
+    install_requires=[
+        'gevent-websocket', 'redis', 'promise==1.0.1', 'graphql-core'
+    ],
+    tests_require=[
+        'pytest', 'pytest-mock', 'fakeredis', 'graphene', 'subprocess32',
+        'flask', 'flask-graphql', 'flask-sockets'
+    ],
     include_package_data=True)

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
     ],
     tests_require=[
         'pytest', 'pytest-mock', 'fakeredis', 'graphene', 'subprocess32',
-        'flask', 'flask-graphql', 'flask-sockets', 'multiprocess'
+        'flask', 'flask-graphql', 'flask-sockets', 'multiprocess', 'requests'
     ],
     include_package_data=True)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     install_requires=[
         'gevent-websocket', 'redis', 'promise==1.0.1', 'graphql-core'
     ],
+    test_suite='pytest',
     tests_require=[
         'pytest', 'pytest-mock', 'fakeredis', 'graphene', 'subprocess32',
         'flask', 'flask-graphql', 'flask-sockets', 'multiprocess', 'requests'

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
     ],
     tests_require=[
         'pytest', 'pytest-mock', 'fakeredis', 'graphene', 'subprocess32',
-        'flask', 'flask-graphql', 'flask-sockets'
+        'flask', 'flask-graphql', 'flask-sockets', 'multiprocess'
     ],
     include_package_data=True)

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,11 @@ try:
 except (IOError, ImportError):
     long_description = open('README.md').read()
 
+tests_dep = [
+    'pytest', 'pytest-mock', 'fakeredis', 'graphene', 'subprocess32',
+    'flask', 'flask-graphql', 'flask-sockets', 'multiprocess', 'requests'
+]
+
 setup(
     name='graphql-subscriptions',
     version='0.1.8',
@@ -27,11 +32,11 @@ setup(
         'License :: OSI Approved :: MIT License'
     ],
     install_requires=[
-        'gevent-websocket', 'redis', 'promise==1.0.1', 'graphql-core'
+        'gevent-websocket', 'redis', 'graphql-core', 'promise<=1.0.1'
     ],
     test_suite='pytest',
-    tests_require=[
-        'pytest', 'pytest-mock', 'fakeredis', 'graphene', 'subprocess32',
-        'flask', 'flask-graphql', 'flask-sockets', 'multiprocess', 'requests'
-    ],
+    tests_require=tests_dep,
+    extras_require={
+        'test': tests_dep
+    },
     include_package_data=True)

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "graphql": "^0.9.6",
+    "subscriptions-transport-ws": "0.5.4"
+  }
+}

--- a/tests/test_subscription_manager.py
+++ b/tests/test_subscription_manager.py
@@ -262,8 +262,7 @@ def test_use_filter_func_that_returns_a_promise(sub_mgr):
 
 
 def test_can_subscribe_to_more_than_one_trigger(sub_mgr):
-    class nonlocal:
-        trigger_count = 0
+    non_local = {'trigger_count': 0}
 
     query = 'subscription multiTrigger($filterBoolean: Boolean,\
             $uga: String){testFilterMulti(filterBoolean: $filterBoolean,\
@@ -278,10 +277,10 @@ def test_can_subscribe_to_more_than_one_trigger(sub_mgr):
                     assert True
                 else:
                     assert payload.data.get('testFilterMulti') == 'good_filter'
-                    nonlocal.trigger_count += 1
+                    non_local['trigger_count'] += 1
             except AssertionError as e:
                 sys.exit(e)
-        if nonlocal.trigger_count == 2:
+        if non_local['trigger_count'] == 2:
             sub_mgr.pubsub.greenlet.kill()
 
     def publish_and_unsubscribe_handler(sub_id):

--- a/tests/test_subscription_manager.py
+++ b/tests/test_subscription_manager.py
@@ -13,12 +13,8 @@ from graphql_subscriptions.validation import SubscriptionHasSingleRootField
 
 
 @pytest.fixture
-def mock_redis(monkeypatch):
+def pubsub(monkeypatch):
     monkeypatch.setattr(redis, 'StrictRedis', fakeredis.FakeStrictRedis)
-
-
-@pytest.fixture
-def pubsub(mock_redis):
     return RedisPubsub()
 
 

--- a/tests/test_subscription_transport.py
+++ b/tests/test_subscription_transport.py
@@ -8,7 +8,6 @@ from functools import wraps
 import copy
 import json
 import os
-import Queue
 import sys
 import threading
 import time
@@ -35,6 +34,11 @@ if os.name == 'posix' and sys.version_info[0] < 3:
     import subprocess32 as subprocess
 else:
     import subprocess
+
+if sys.version_info[0] < 3:
+    import Queue
+else:
+    import queue as Queue
 
 TEST_PORT = 5000
 KEEP_ALIVE_TEST_PORT = TEST_PORT + 1

--- a/tests/test_subscription_transport.py
+++ b/tests/test_subscription_transport.py
@@ -7,7 +7,6 @@
 from functools import wraps
 import copy
 import json
-import multiprocess
 import os
 import sys
 
@@ -18,6 +17,7 @@ from geventwebsocket import WebSocketServer
 from promise import Promise
 import fakeredis
 import graphene
+import multiprocess
 import pytest
 import redis
 

--- a/tests/test_subscription_transport.py
+++ b/tests/test_subscription_transport.py
@@ -27,8 +27,8 @@ import requests
 from graphql_subscriptions import (RedisPubsub, SubscriptionManager,
                                    SubscriptionServer)
 
-from graphql_subscriptions.subscription_transport_ws import (
-    SUBSCRIPTION_FAIL, SUBSCRIPTION_DATA)
+from graphql_subscriptions.subscription_transport_ws import (SUBSCRIPTION_FAIL,
+                                                             SUBSCRIPTION_DATA)
 
 if os.name == 'posix' and sys.version_info[0] < 3:
     import subprocess32 as subprocess
@@ -338,8 +338,7 @@ def test_should_trigger_on_connect_if_client_connect_valid(server_with_mocks):
         require('subscriptions-transport-ws').SubscriptionClient
         new SubscriptionClient('ws://localhost:{1}/socket')
     '''.format(
-        os.path.join(os.path.dirname(__file__), 'node_modules'),
-        TEST_PORT)
+        os.path.join(os.path.dirname(__file__), 'node_modules'), TEST_PORT)
     try:
         subprocess.check_output(
             ['node', '-e', node_script], stderr=subprocess.STDOUT, timeout=.2)
@@ -360,8 +359,7 @@ def test_should_trigger_on_connect_with_correct_cxn_params(server_with_mocks):
         connectionParams,
         }})
     '''.format(
-        os.path.join(os.path.dirname(__file__), 'node_modules'),
-        TEST_PORT)
+        os.path.join(os.path.dirname(__file__), 'node_modules'), TEST_PORT)
     try:
         subprocess.check_output(
             ['node', '-e', node_script], stderr=subprocess.STDOUT, timeout=.2)
@@ -381,8 +379,7 @@ def test_trigger_on_disconnect_when_client_disconnects(server_with_mocks):
         const client = new SubscriptionClient('ws://localhost:{1}/socket')
         client.client.close()
     '''.format(
-        os.path.join(os.path.dirname(__file__), 'node_modules'),
-        TEST_PORT)
+        os.path.join(os.path.dirname(__file__), 'node_modules'), TEST_PORT)
     subprocess.check_output(['node', '-e', node_script])
     mock = server_with_mocks.get_nowait()
     assert mock.name == 'on_disconnect'
@@ -415,8 +412,7 @@ def test_should_call_unsubscribe_when_client_closes_cxn(server_with_mocks):
             client.client.close()
         }}, 500)
     '''.format(
-        os.path.join(os.path.dirname(__file__), 'node_modules'),
-        TEST_PORT)
+        os.path.join(os.path.dirname(__file__), 'node_modules'), TEST_PORT)
     try:
         subprocess.check_output(
             ['node', '-e', node_script], stderr=subprocess.STDOUT, timeout=1)
@@ -450,8 +446,7 @@ def test_should_trigger_on_subscribe_when_client_subscribes(server_with_mocks):
             // nothing
           }})
     '''.format(
-        os.path.join(os.path.dirname(__file__), 'node_modules'),
-        TEST_PORT)
+        os.path.join(os.path.dirname(__file__), 'node_modules'), TEST_PORT)
     try:
         subprocess.check_output(
             ['node', '-e', node_script], stderr=subprocess.STDOUT, timeout=.2)
@@ -487,8 +482,7 @@ def test_should_trigger_on_unsubscribe_when_client_unsubscribes(
           }})
         client.unsubscribe(subId)
     '''.format(
-        os.path.join(os.path.dirname(__file__), 'node_modules'),
-        TEST_PORT)
+        os.path.join(os.path.dirname(__file__), 'node_modules'), TEST_PORT)
     try:
         subprocess.check_output(
             ['node', '-e', node_script], stderr=subprocess.STDOUT, timeout=.2)
@@ -960,7 +954,6 @@ def test_rejects_client_that_does_not_specifiy_a_supported_protocol(server):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT)
-    time.sleep(.2)
     q = Queue.Queue()
     t = threading.Thread(target=enqueue_output, args=(p.stdout, q))
     t.daemon = True
@@ -1003,7 +996,6 @@ def test_rejects_unparsable_message(server):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT)
-    time.sleep(.2)
     q = Queue.Queue()
     t = threading.Thread(target=enqueue_output, args=(p.stdout, q))
     t.daemon = True
@@ -1047,7 +1039,6 @@ def test_rejects_nonsense_message(server):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT)
-    time.sleep(.2)
     q = Queue.Queue()
     t = threading.Thread(target=enqueue_output, args=(p.stdout, q))
     t.daemon = True
@@ -1094,7 +1085,6 @@ def test_does_not_crash_on_unsub_from_unknown_sub(server):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT)
-    time.sleep(.2)
     q = Queue.Queue()
     t = threading.Thread(target=enqueue_output, args=(p.stdout, q))
     t.daemon = True
@@ -1245,7 +1235,6 @@ def test_sends_a_keep_alive_signal_in_the_socket(server_with_keep_alive):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT)
-    time.sleep(.5)
     q = Queue.Queue()
     t = threading.Thread(target=enqueue_output, args=(p.stdout, q))
     t.daemon = True

--- a/tests/test_subscription_transport.py
+++ b/tests/test_subscription_transport.py
@@ -1,0 +1,458 @@
+# Many, if not most of these tests rely on using a graphql subscriptions
+# client.  "apollographql/subscriptions-transport-ws" is used here for testing
+# the graphql subscriptions server implementation. In order to run these tests,
+# "cd" to the "tests" directory and "npm install".  Make sure you have nodejs
+# installed in your $PATH.
+
+from functools import wraps
+import copy
+import json
+import multiprocess
+import os
+import sys
+
+from flask import Flask
+from flask_graphql import GraphQLView
+from flask_sockets import Sockets
+from geventwebsocket import WebSocketServer
+from promise import Promise
+import fakeredis
+import graphene
+import pytest
+import redis
+
+from graphql_subscriptions import (RedisPubsub, SubscriptionManager,
+                                   ApolloSubscriptionServer)
+
+from graphql_subscriptions.subscription_transport_ws import (
+    SUBSCRIPTION_START, SUBSCRIPTION_FAIL, SUBSCRIPTION_DATA, KEEPALIVE,
+    SUBSCRIPTION_END)
+
+if os.name == 'posix' and sys.version_info[0] < 3:
+    import subprocess32 as subprocess
+else:
+    import subprocess
+
+TEST_PORT = 5000
+KEEP_ALIVE_TEST_PORT = TEST_PORT + 1
+DELAYED_TEST_PORT = TEST_PORT + 2
+RAW_TEST_PORT = TEST_PORT + 4
+EVENTS_TEST_PORT = TEST_PORT + 5
+
+
+class PickableMock():
+    def __init__(self, return_value=None, side_effect=None, name=None):
+        self._return_value = return_value
+        self._side_effect = side_effect
+        self.name = name
+        self.called = False
+        self.call_count = 0
+        self.call_args = set()
+
+    def __call__(mock_self, *args, **kwargs):
+        mock_self.called = True
+        mock_self.call_count += 1
+        call_args = {repr(arg) for arg in args}
+        call_kwargs = {repr(item) for item in kwargs}
+        mock_self.call_args = call_args | call_kwargs | mock_self.call_args
+
+        if mock_self._side_effect and mock_self._return_value:
+            mock_self._side_effect(mock_self, *args, **kwargs)
+            return mock_self._return_value
+        elif mock_self._side_effect:
+            return mock_self._side_effect(mock_self, *args, **kwargs)
+        elif mock_self._return_value:
+            return mock_self._return_value
+
+    def assert_called_once(self):
+        assert self.call_count == 1
+
+    def assert_called_with(self, *args, **kwargs):
+        call_args = {repr(json.loads(json.dumps(arg))) for arg in args}
+        call_kwargs = {repr(json.loads(json.dumps(item))) for item in kwargs}
+        all_call_args = call_args | call_kwargs
+        assert all_call_args.issubset(self.call_args)
+
+
+def promisify(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        def executor(resolve, reject):
+            return resolve(f(*args, **kwargs))
+
+        return Promise(executor)
+
+    return wrapper
+
+
+@pytest.fixture
+def data():
+    return {
+        '1': {
+            'id': '1',
+            'name': 'Dan'
+        },
+        '2': {
+            'id': '2',
+            'name': 'Marie'
+        },
+        '3': {
+            'id': '3',
+            'name': 'Jessie'
+        }
+    }
+
+
+@pytest.fixture
+def pubsub(monkeypatch):
+    monkeypatch.setattr(redis, 'StrictRedis', fakeredis.FakeStrictRedis)
+    return RedisPubsub()
+
+
+@pytest.fixture
+def schema(data):
+    class UserType(graphene.ObjectType):
+        id = graphene.String()
+        name = graphene.String()
+
+    class Query(graphene.ObjectType):
+        test_string = graphene.String()
+
+    class Subscription(graphene.ObjectType):
+        user = graphene.Field(UserType, id=graphene.String())
+        user_filtered = graphene.Field(UserType, id=graphene.String())
+        context = graphene.String()
+        error = graphene.String()
+
+        def resolve_user(self, args, context, info):
+            id = args['id']
+            name = data[args['id']]['name']
+            return UserType(id=id, name=name)
+
+        def resolve_user_filtered(self, args, context, info):
+            id = args['id']
+            name = data[args['id']]['name']
+            return UserType(id=id, name=name)
+
+        def resolve_context(self, args, context, info):
+            return context
+
+        def resolve_error(self, args, context, info):
+            raise Exception('E1')
+
+    return graphene.Schema(query=Query, subscription=Subscription)
+
+
+@pytest.fixture
+def sub_mgr(pubsub, schema):
+    def user_filtered_func(**kwargs):
+        args = kwargs.get('args')
+        return {
+            'user_filtered': {
+                'filter': lambda root, ctx: root.get('id') == args.get('id')
+            }
+        }
+
+    setup_funcs = {'user_filtered': user_filtered_func}
+
+    return SubscriptionManager(schema, pubsub, setup_funcs)
+
+
+@pytest.fixture
+def handlers():
+    def copy_and_update_dict(msg, params, websocket):
+        new_params = copy.deepcopy(params)
+        new_params.update({'context': msg['context']})
+        return new_params
+
+    return {'on_subscribe': promisify(copy_and_update_dict)}
+
+
+@pytest.fixture
+def options(handlers):
+    return {
+        'on_subscribe':
+        lambda msg, params, ws: handlers['on_subscribe'](msg, params, ws)
+    }
+
+
+@pytest.fixture
+def events_options(mocker):
+
+    mgr = multiprocess.Manager()
+    q = mgr.Queue()
+
+    def on_subscribe(self, msg, params, websocket):
+        new_params = copy.deepcopy(params)
+        new_params.update({'context': msg.get('context', {})})
+        q.put(self)
+        return new_params
+
+    def on_connect(self, message, websocket):
+        q.put(self)
+
+    def on_disconnect(self, websocket):
+        q.put(self)
+
+    def on_unsubscribe(self, websocket):
+        q.put(self)
+
+    events_options = {
+        'on_subscribe':
+        PickableMock(side_effect=promisify(on_subscribe), name='on_subscribe'),
+        'on_unsubscribe':
+        PickableMock(side_effect=on_unsubscribe, name='on_unsubscribe'),
+        'on_connect':
+        PickableMock(
+            return_value={'test': 'test_context'},
+            side_effect=on_connect,
+            name='on_connect'),
+        'on_disconnect':
+        PickableMock(side_effect=on_disconnect, name='on_disconnect')
+    }
+
+    return events_options, q
+
+
+def create_app(sub_mgr, schema, options):
+    app = Flask(__name__)
+    sockets = Sockets(app)
+
+    app.app_protocol = lambda environ_path_info: 'graphql-subscriptions'
+
+    app.add_url_rule(
+        '/graphql',
+        view_func=GraphQLView.as_view('graphql', schema=schema, graphiql=True))
+
+    @sockets.route('/socket')
+    def socket_channel(websocket):
+        subscription_server = ApolloSubscriptionServer(sub_mgr, websocket,
+                                                       **options)
+        subscription_server.handle()
+        return []
+
+    return app
+
+
+def app_worker(app, port):
+    server = WebSocketServer(('', port), app)
+    server.serve_forever()
+
+
+@pytest.fixture()
+def server(sub_mgr, schema, options):
+
+    app = create_app(sub_mgr, schema, options)
+
+    process = multiprocess.Process(
+        target=app_worker, kwargs={'app': app,
+                                   'port': TEST_PORT})
+    process.start()
+    yield
+    process.terminate()
+
+
+@pytest.fixture()
+def server_with_keep_alive(sub_mgr, schema, options):
+
+    options_with_keep_alive = options.copy()
+    options_with_keep_alive.update({'keep_alive': 10})
+    app = create_app(sub_mgr, schema, options_with_keep_alive)
+
+    process = multiprocess.Process(
+        target=app_worker, kwargs={'app': app,
+                                   'port': KEEP_ALIVE_TEST_PORT})
+    process.start()
+    yield
+    process.terminate()
+
+
+@pytest.fixture()
+def server_with_events(sub_mgr, schema, events_options):
+
+    options, q = events_options
+    app = create_app(sub_mgr, schema, options)
+
+    process = multiprocess.Process(
+        target=app_worker, kwargs={'app': app,
+                                   'port': EVENTS_TEST_PORT})
+
+    process.start()
+    yield q
+    process.terminate()
+
+
+def test_raise_exception_when_create_server_and_no_sub_mgr():
+    with pytest.raises(AssertionError):
+        ApolloSubscriptionServer(None, None)
+
+
+def test_should_trigger_on_connect_if_client_connect_valid(server_with_events):
+    node_script = '''
+        module.paths.push('{0}')
+        WebSocket = require('ws')
+        const SubscriptionClient =
+        require('subscriptions-transport-ws').SubscriptionClient
+        new SubscriptionClient('ws://localhost:{1}/socket')
+    '''.format(
+        os.path.join(os.path.dirname(__file__), 'node_modules'),
+        EVENTS_TEST_PORT)
+    try:
+        subprocess.check_output(
+            ['node', '-e', node_script], stderr=subprocess.STDOUT, timeout=.2)
+    except:
+        ret_value = server_with_events.get_nowait()
+        assert ret_value.name == 'on_connect'
+        ret_value.assert_called_once()
+
+
+def test_should_trigger_on_connect_with_correct_cxn_params(server_with_events):
+    node_script = '''
+        module.paths.push('{0}')
+        WebSocket = require('ws')
+        const SubscriptionClient =
+        require('subscriptions-transport-ws').SubscriptionClient
+        const connectionParams = {{test: true}}
+        new SubscriptionClient('ws://localhost:{1}/socket', {{
+        connectionParams,
+        }})
+    '''.format(
+        os.path.join(os.path.dirname(__file__), 'node_modules'),
+        EVENTS_TEST_PORT)
+    try:
+        subprocess.check_output(
+            ['node', '-e', node_script], stderr=subprocess.STDOUT, timeout=.2)
+    except:
+        ret_value = server_with_events.get_nowait()
+        assert ret_value.name == 'on_connect'
+        ret_value.assert_called_once()
+        ret_value.assert_called_with({'test': True})
+
+
+def test_trigger_on_disconnect_when_client_disconnects(server_with_events):
+    node_script = '''
+        module.paths.push('{0}')
+        WebSocket = require('ws')
+        const SubscriptionClient =
+        require('subscriptions-transport-ws').SubscriptionClient
+        const client = new SubscriptionClient('ws://localhost:{1}/socket')
+        client.client.close()
+    '''.format(
+        os.path.join(os.path.dirname(__file__), 'node_modules'),
+        EVENTS_TEST_PORT)
+    subprocess.check_output(['node', '-e', node_script])
+    ret_value = server_with_events.get_nowait()
+    assert ret_value.name == 'on_disconnect'
+    ret_value.assert_called_once()
+
+
+def test_should_call_unsubscribe_when_client_closes_cxn(server_with_events):
+    node_script = '''
+        module.paths.push('{0}')
+        WebSocket = require('ws')
+        const SubscriptionClient =
+        require('subscriptions-transport-ws').SubscriptionClient
+        const client = new SubscriptionClient('ws://localhost:{1}/socket')
+        client.subscribe({{
+            query: `subscription useInfo($id: String) {{
+            user(id: $id) {{
+              id
+              name
+            }}
+          }}`,
+            operationName: 'useInfo',
+            variables: {{
+              id: 3,
+            }},
+          }}, function (error, result) {{
+            // nothing
+          }}
+        )
+        setTimeout(() => {{
+            client.client.close()
+        }}, 500)
+    '''.format(
+        os.path.join(os.path.dirname(__file__), 'node_modules'),
+        EVENTS_TEST_PORT)
+    try:
+        subprocess.check_output(
+            ['node', '-e', node_script], stderr=subprocess.STDOUT, timeout=1)
+    except:
+        while True:
+            ret_value = server_with_events.get_nowait()
+            if ret_value.name == 'on_unsubscribe':
+                ret_value.assert_called_once()
+                break
+
+
+def test_should_trigger_on_subscribe_when_client_subscribes(
+        server_with_events):
+    node_script = '''
+        module.paths.push('{0}')
+        WebSocket = require('ws')
+        const SubscriptionClient =
+        require('subscriptions-transport-ws').SubscriptionClient
+        const client = new SubscriptionClient('ws://localhost:{1}/socket')
+        client.subscribe({{
+            query: `subscription useInfo($id: String) {{
+            user(id: $id) {{
+              id
+              name
+            }}
+          }}`,
+            operationName: 'useInfo',
+            variables: {{
+              id: 3,
+            }},
+          }}, function (error, result) {{
+            // nothing
+          }})
+    '''.format(
+        os.path.join(os.path.dirname(__file__), 'node_modules'),
+        EVENTS_TEST_PORT)
+    try:
+        subprocess.check_output(
+            ['node', '-e', node_script], stderr=subprocess.STDOUT, timeout=.2)
+    except:
+        while True:
+            ret_value = server_with_events.get_nowait()
+            if ret_value.name == 'on_subscribe':
+                ret_value.assert_called_once()
+                break
+
+
+def test_should_trigger_on_unsubscribe_when_client_unsubscribes(
+        server_with_events):
+    node_script = '''
+        module.paths.push('{0}')
+        WebSocket = require('ws')
+        const SubscriptionClient =
+        require('subscriptions-transport-ws').SubscriptionClient
+        const client = new SubscriptionClient('ws://localhost:{1}/socket')
+        const subId = client.subscribe({{
+            query: `subscription useInfo($id: String) {{
+            user(id: $id) {{
+              id
+              name
+            }}
+          }}`,
+            operationName: 'useInfo',
+            variables: {{
+              id: 3,
+            }},
+          }}, function (error, result) {{
+            // nothing
+          }})
+        client.unsubscribe(subId)
+    '''.format(
+        os.path.join(os.path.dirname(__file__), 'node_modules'),
+        EVENTS_TEST_PORT)
+    try:
+        subprocess.check_output(
+            ['node', '-e', node_script], stderr=subprocess.STDOUT, timeout=.2)
+    except:
+        while True:
+            ret_value = server_with_events.get_nowait()
+            if ret_value.name == 'on_unsubscribe':
+                ret_value.assert_called_once()
+                break

--- a/tests/test_subscription_transport.py
+++ b/tests/test_subscription_transport.py
@@ -25,7 +25,7 @@ import redis
 import requests
 
 from graphql_subscriptions import (RedisPubsub, SubscriptionManager,
-                                   ApolloSubscriptionServer)
+                                   SubscriptionServer)
 
 from graphql_subscriptions.subscription_transport_ws import (
     SUBSCRIPTION_FAIL, SUBSCRIPTION_DATA, KEEPALIVE)
@@ -264,7 +264,7 @@ def create_app(sub_mgr, schema, options):
 
     @sockets.route('/socket')
     def socket_channel(websocket):
-        subscription_server = ApolloSubscriptionServer(sub_mgr, websocket,
+        subscription_server = SubscriptionServer(sub_mgr, websocket,
                                                        **options)
         subscription_server.handle()
         return []
@@ -323,7 +323,7 @@ def server_with_events(sub_mgr, schema, events_options):
 
 def test_raise_exception_when_create_server_and_no_sub_mgr():
     with pytest.raises(AssertionError):
-        ApolloSubscriptionServer(None, None)
+        SubscriptionServer(None, None)
 
 
 def test_should_trigger_on_connect_if_client_connect_valid(server_with_events):


### PR DESCRIPTION
See notes in tests/test_subscription_transport.py for how to run
tests. This implementation is based on the
[apollographql/subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws) library and uses their
graphql subscriptions client for testing. Specifically, these
tests are compatable with npm package released version
subscriptions-transport-ws@0.5.4.

Tests are about halfway complete for that release version.